### PR TITLE
Fix Vercel deployment

### DIFF
--- a/server.js
+++ b/server.js
@@ -52,7 +52,7 @@ const anthropic = new Anthropic({
 // Middleware
 app.use(cors());
 app.use(express.json({ limit: '10mb' }));
-app.use(express.static('public'));
+app.use(express.static(path.join(__dirname, 'public')));
 
 // Serve the main HTML page
 app.get('/', (req, res) => {

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,12 @@
   "builds": [
     {
       "src": "server.js",
-      "use": "@vercel/node"
+      "use": "@vercel/node",
+      "config": {
+        "includeFiles": [
+          "public/**"
+        ]
+      }
     }
   ],
   "routes": [
@@ -13,7 +18,10 @@
       "dest": "/server.js"
     },
     {
-      "src": "/",
+      "handle": "filesystem"
+    },
+    {
+      "src": "/(.*)",
       "dest": "/server.js"
     }
   ],


### PR DESCRIPTION
## Summary
- include `public` directory in Vercel build output
- serve static files correctly from Express
- add filesystem handler to Vercel routes so static assets are used first

## Testing
- `npm test`
- `npm run check-api-keys`


------
https://chatgpt.com/codex/tasks/task_e_68839df6f3a4832792036cd487f71a8c